### PR TITLE
Fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ After years of working extensively with React and other modern JavaScript framew
 
 ## Playing
 
-The game can be found online at [alexd99.github.io/miners-foundry/](alexd99.github.io/miners-foundry/) all progress is saved automatically in local storage.
+The game can be found online at [alexd99.github.io/miners-foundry/](https://alexd99.github.io/miners-foundry/) all progress is saved automatically in local storage.


### PR DESCRIPTION
I was flabbergasted when I clicked the link in the README to play this incredible game, and it did not work. This patch should prevent other potential players from being turned away by broke link